### PR TITLE
Issue #2. Added new parameter for prompt that user should define

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Example in `pom.xml`:
             <configuration>
                 <inputFileWithBugs>${build.directory}/spotbugsXml.xml</inputFileWithBugs>
                 <modelName>qwen2.5</modelName>
+                <prompt>SpotBugs after analysis gives this error. Suggest a fix. The error: %bugContent%. Keep the answer small and precise, code mostly.</prompt>
             </configuration>
         </plugin>
     </plugins>

--- a/src/main/java/com/salat/suggester/SuggesterMojo.java
+++ b/src/main/java/com/salat/suggester/SuggesterMojo.java
@@ -41,6 +41,17 @@ public class SuggesterMojo extends AbstractMavenReport {
     private String modelName;
 
     /**
+     * Prompt for specified model.
+     * <br><br>
+     * Supports arguments placement:
+     * <ul>
+     *     <li><pre>%bugContent%</pre> will be replaced by actual bug description</li>
+     * </ul>
+     */
+    @Parameter(property = "prompt", readonly = true, required = true)
+    private String prompt;
+
+    /**
      * Request timeout to model in seconds. Default is 3 seconds.
      */
     @Parameter(property = "modelRequestTimeout", defaultValue = "3", readonly = true)
@@ -94,8 +105,7 @@ public class SuggesterMojo extends AbstractMavenReport {
             OllamaChatRequest request = OllamaChatRequestBuilder.getInstance(modelName)
                     .withMessage(
                             OllamaChatMessageRole.ASSISTANT,
-                            "SpotBugs after analysis gives this error. Suggest a fix. The error: \"" + bug.content() + "\". " +
-                                    "Keep the answer small and precise, code mostly."
+                            prompt.replace("%bugContent%", bug.content())
                     )
                     .build();
             OllamaChatResult result = ollamaAPI.chat(request);


### PR DESCRIPTION
# Problem

Prompt for model is hardcoded and end user cannot change it.

# Solution

Adder parameter for plugin that accepts prompt with argument `%bugContent%` for specifying actual bug description.